### PR TITLE
Go full Async

### DIFF
--- a/AsyncFileWriter/AsyncFileWriter.cs
+++ b/AsyncFileWriter/AsyncFileWriter.cs
@@ -60,19 +60,17 @@ namespace Open
 		async Task ProcessBytes()
 		{
 			var reader = _channel.Reader;
-			using (var fs = new FileStream(FilePath, FileMode.Append, FileAccess.Write, FileShareMode, bufferSize: 4096 * 4, useAsync: true))
+			using (var fs = new FileStream(FilePath, FileMode.Append, FileAccess.Write, FileShareMode, bufferSize: 4096 * 4 /*, useAsync: true */))
 			{
-				Task writeTask = Task.CompletedTask;
 				while (await reader.WaitToReadAsync().ConfigureAwait(false))
 				{
 					while (reader.TryRead(out byte[] bytes))
 					{
-						await writeTask.ConfigureAwait(false);
-						writeTask = fs.WriteAsync(bytes, 0, bytes.Length);
+						//await fs.WriteAsync(bytes, 0, bytes.Length).ConfigureAwait(false);
+						fs.Write(bytes, 0, bytes.Length);
 					}
 				}
 
-				await writeTask.ConfigureAwait(false);
 				// FlushAsync here rather than block in Dispose on Flush
 				await fs.FlushAsync().ConfigureAwait(false);
 			}

--- a/AsyncFileWriter/IDisposableAsync.cs
+++ b/AsyncFileWriter/IDisposableAsync.cs
@@ -1,0 +1,9 @@
+﻿using System.Threading.Tasks;
+
+namespace Open
+{
+    interface IDisposableAsync
+    {
+        Task DisposeAsync();
+    }
+}

--- a/AsyncFileWriterTester/AsyncFileWriterTester.csproj
+++ b/AsyncFileWriterTester/AsyncFileWriterTester.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.0</TargetFramework>
+    <LangVersion>7.2</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/AsyncFileWriterTester/Program.cs
+++ b/AsyncFileWriterTester/Program.cs
@@ -1,6 +1,7 @@
 ﻿using Open;
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -12,112 +13,173 @@ namespace AsyncFileWriterTester
 {
 	class Program
 	{
-		static void Main(string[] args)
+		static async Task Main(string[] args)
 		{
-			//TestSynchronizedFileStream();
-			TestAsyncFileWriter(100000);
-			TestAsyncFileWriter(10000);
-			TestAsyncFileWriter(1000);
-			TestAsyncFileWriter(100);
-			//TestMultipleFileStreams();
+			//await TestSynchronizedFileStream();
+			await TestAsyncFileWriter(100000);
+			await TestAsyncFileWriter(10000);
+			await TestAsyncFileWriter(1000);
+			await TestAsyncFileWriter(100);
+			//await TestMultipleFileStreams();
 
 			Console.WriteLine("Press ENTER to continue.");
 			Console.ReadLine();
 		}
 
-		static void TestSynchronizedFileStream()
+		static SemaphoreSlim semaphoreSlim = new SemaphoreSlim(1);
+
+		static Task TestSynchronizedFileStream()
 		{
 			Console.WriteLine($"Synchronized file stream benchmark.");
-			Test((filePath, handler) =>
+			return TestAsync(async (filePath, handler) =>
 			{
-				using (var fs = new FileStream(filePath, FileMode.Append, FileAccess.Write, FileShare.None))
+				using (var fs = new FileStream(filePath, FileMode.Append, FileAccess.Write, FileShare.None, bufferSize: 4096 * 4, useAsync: true))
 				using (var sw = new StreamWriter(fs))
 				{
-					handler(s =>
+					await handler(async s =>
 					{
-						lock (sw) sw.Write(s);
+						await semaphoreSlim.WaitAsync().ConfigureAwait(false);
+						try
+						{
+							await sw.WriteAsync(s).ConfigureAwait(false);
+						}
+						finally
+						{
+							semaphoreSlim.Release();
+						}
 					});
+
+					// FlushAsync here rather than block in Dispose on Flush
+					await sw.FlushAsync().ConfigureAwait(false);
+					await fs.FlushAsync().ConfigureAwait(false);
 				}
 			});
 		}
 
-		static void TestMultipleFileStreams()
+		static Task TestMultipleFileStreams()
 		{
 			Console.WriteLine($"Multiple file stream benchmark.");
-			Test((filePath, handler) =>
+			return TestAsync(async (filePath, handler) =>
 			{
-				handler(s =>
+				await handler(async s =>
 				{
-					using (var fs = new FileStream(filePath, FileMode.Append, FileAccess.Write, FileShare.Write))
+					using (var fs = new FileStream(filePath, FileMode.Append, FileAccess.Write, FileShare.Write, bufferSize: 4096 * 4, useAsync: true))
 					using (var sw = new StreamWriter(fs))
-						sw.Write(s);
+					{
+						await sw.WriteAsync(s).ConfigureAwait(false);
+
+						// FlushAsync here rather than block in Dispose on Flush
+						await sw.FlushAsync().ConfigureAwait(false);
+						await fs.FlushAsync().ConfigureAwait(false);
+					}
 				});
 			});
 		}
 
-		static void TestAsyncFileWriter(int boundedCapacity = -1)
+		static Task TestAsyncFileWriter(int boundedCapacity = -1)
 		{
 			Console.WriteLine("{0:#,##0} bounded capacity.", boundedCapacity);
-			Test((filePath, handler) =>
+			return TestAsync(async (filePath, asyncHandler) =>
 			{
-				using (var writer = new AsyncFileWriter(filePath, boundedCapacity))
-					handler(s => writer.AddAsync(s).Wait());
+				var writer = new AsyncFileWriter(filePath, boundedCapacity);
+				try
+				{
+					await asyncHandler(s => writer.AddAsync(s)).ConfigureAwait(false);
+				}
+				finally
+				{
+					await writer.DisposeAsync().ConfigureAwait(false);
+				}
 			});
 		}
 
-		static void Test(Action<string, Action<Action<string>>> context)
+		static ConcurrentBag<Telemetry> Counter = new ConcurrentBag<Telemetry>();
+		static int count = 0;
+
+		struct Telemetry
 		{
+			public int Bytes;
+			public TimeSpan Time;
+		}
+
+		static async Task TestAsync(Func<string, Func<Func<string, Task>, Task>, Task> context)
+		{
+			Counter.Clear();
+			count = 0;
+
 			var dir = Environment.CurrentDirectory;
 			var filePath = Path.Combine(dir, "AsyncFileWriterTest.txt");
 			File.Delete(filePath); // Start from scratch. (comment out for further appends.)
 
-			var byteCounter = new ConcurrentBag<int>();
-			var timeCounter = new ConcurrentBag<TimeSpan>();
-
 			var sw = Stopwatch.StartNew();
-			context(filePath, writeHandler =>
-			{
-				int count = 0;
-				void write(int i)
-				{
-					var message = $"{i}) {DateTime.Now} 00000000000000000000000000000000111111111111111111111111111222222222222222222222222222\n";
-					var t = Stopwatch.StartNew();
-					writeHandler(message);
-					timeCounter.Add(t.Elapsed);
-					byteCounter.Add(message.Length);
-					Interlocked.Increment(ref count);
-				}
-
-				Parallel.For(0, 10000, write);
-				Parallel.For(10000, 20000, write);
-
-				//writer.Fault(new Exception("Stop!"));
-
-				Task.Delay(1).Wait();
-				Parallel.For(20000, 100000, write);
-
-				Task.Delay(1000).Wait(); // Demonstrate that when nothing buffered the active stream closes.
-				Parallel.For(100000, 1000000, write);
-
-				//Console.WriteLine("Total Posted: {0:#,##0}", count);
-			});
+			await context(filePath, asyncHandler => RunAsync(asyncHandler)).ConfigureAwait(false);
 
 			Console.WriteLine($"Total Time: {sw.Elapsed.TotalSeconds} seconds");
-			Console.WriteLine("Total Bytes: {0:#,##0}", byteCounter.Sum());
-			Console.WriteLine($"Total Blocking Time: {timeCounter.Aggregate((b, c) => b + c)}");
+			Console.WriteLine($"Total Bytes: {Counter.Aggregate((b, c) => new Telemetry() { Bytes = b.Bytes + c.Bytes }).Bytes:#,##0}");
+			Console.WriteLine($"Total Wait Time: {Counter.Aggregate((b, c) => new Telemetry() { Time = b.Time + c.Time }).Time}");
 			Console.WriteLine("------------------------");
 			Console.WriteLine();
-
 		}
 
-		static void Dump<T>(ISourceBlock<T> source, ITargetBlock<T> target)
+		static async Task RunAsync(Func<string, Task> asyncHandler)
+		{
+			await ParallelAsync.ForAsync(0, 10000, (i, s) => WriteAsync(i, s), asyncHandler).ConfigureAwait(false);
+			await ParallelAsync.ForAsync(10000, 20000, (i, s) => WriteAsync(i, s), asyncHandler).ConfigureAwait(false);
+
+			//writer.Fault(new Exception("Stop!"));
+
+			await Task.Delay(1);
+			await ParallelAsync.ForAsync(20000, 100000, (i, s) => WriteAsync(i, s), asyncHandler).ConfigureAwait(false);
+
+			await Task.Delay(1000); // Demonstrate that when nothing buffered the active stream closes.
+			await ParallelAsync.ForAsync(100000, 1000000, (i, s) => WriteAsync(i, s), asyncHandler).ConfigureAwait(false);
+
+			//Console.WriteLine("Total Posted: {0:#,##0}", count);
+		}
+
+		static async Task WriteAsync(int i, Func<string, Task> asyncHandler)
+		{
+			var message = $"{i}) {DateTime.Now}\n 00000000000000000000000000000000111111111111111111111111111222222222222222222222222222";
+			var t = Stopwatch.StartNew();
+			await asyncHandler(message).ConfigureAwait(false);
+			t.Stop();
+			Counter.Add(new Telemetry() { Time = t.Elapsed, Bytes = message.Length });
+			Interlocked.Increment(ref count);
+		}
+
+		static async Task Dump<T>(ISourceBlock<T> source, ITargetBlock<T> target)
 		{
 			using (source.LinkTo(target, new DataflowLinkOptions { PropagateCompletion = true }))
 			{
 				source.Complete();
-				source.Completion.Wait();
+				await source.Completion.ConfigureAwait(false);
 			}
-			target.Completion.Wait();
+			await target.Completion.ConfigureAwait(false);
+		}
+	}
+
+	static class ParallelAsync
+	{
+		public static Task ForAsync<TState>(int fromInclusive, int toExclusive, Func<int, TState, Task> bodyAsync, TState state)
+		{
+			int procCount = Environment.ProcessorCount;
+			int groupSize = (toExclusive - fromInclusive) / procCount;
+
+			List<Task> tasks = new List<Task>();
+			for (int p = 0; p < procCount; p++)
+			{
+				var start = fromInclusive + groupSize * p;
+				var end = p == procCount - 1 ? toExclusive : fromInclusive + groupSize * (p + 1);
+				tasks.Add(Task.Run(() => ForAsyncPartition(start, end, bodyAsync, state)));
+			}
+
+			return Task.WhenAll(tasks);
+		}
+
+		private static async Task ForAsyncPartition<TState>(int fromInclusive, int toExclusive, Func<int, TState, Task> bodyAsync, TState state)
+		{
+			for (var i = fromInclusive; i < toExclusive; i++)
+				await bodyAsync(i, state).ConfigureAwait(false);
 		}
 	}
 }


### PR DESCRIPTION
Is currently blocking in some of the paths; making it fully async gives no significant drop off and the `FileStream` can then also be async.
```
AsyncFileWriterTester>dotnet run -c Release
100,000 bounded capacity.
Total Time: 1.9647976 seconds
Total Bytes: 115,888,890
Total Wait Time: 00:00:02.3469906
------------------------

10,000 bounded capacity.
Total Time: 1.7327357 seconds
Total Bytes: 115,888,890
Total Wait Time: 00:00:01.8846596
------------------------

1,000 bounded capacity.
Total Time: 1.7522801 seconds
Total Bytes: 115,888,890
Total Wait Time: 00:00:02.2072572
------------------------

100 bounded capacity.
Total Time: 1.7023758 seconds
Total Bytes: 115,888,890
Total Wait Time: 00:00:01.9285510
------------------------

Press ENTER to continue.
```